### PR TITLE
Implement time metric, flushing queue, popping chunks and more

### DIFF
--- a/lib/membrane/timestamp_queue.ex
+++ b/lib/membrane/timestamp_queue.ex
@@ -570,7 +570,8 @@ defmodule Membrane.TimestampQueue do
   @doc """
   Pops all items in the proper order and closes the queue.
 
-  After being closed, queue is unable handle any new buffer/stream format/event/end of stream.
+  After being closed, nothing can be pushed to the queue anymore - a new queue should be created if
+  needed.
 
   The returned value is a suggested actions list, a list of popped buffers and the updated queue.
 

--- a/lib/membrane/timestamp_queue.ex
+++ b/lib/membrane/timestamp_queue.ex
@@ -121,7 +121,7 @@ defmodule Membrane.TimestampQueue do
 
       pad_queue =
         pad_queue
-        |> Map.update!(:buffers_number, &(&1 - 1))
+        |> Map.update!(:buffers_number, &(&1 + 1))
         |> Map.update!(:timestamp_offset, fn
           nil -> timestamp_queue.current_queue_time - (buffer.dts || buffer.pts)
           valid_offset -> valid_offset
@@ -387,6 +387,7 @@ defmodule Membrane.TimestampQueue do
           else: []
 
       items = [{pad_ref, {:buffer, buffer}}]
+
 
       pop_following_items(timestamp_queue, pad_ref, actions, items)
     else

--- a/lib/membrane/timestamp_queue.ex
+++ b/lib/membrane/timestamp_queue.ex
@@ -151,10 +151,6 @@ defmodule Membrane.TimestampQueue do
             nil -> buffer.dts == nil
             valid_boolean -> valid_boolean
           end)
-          |> Map.update!(:timestamps_qex, fn
-            nil when timestamp_queue.metric_unit == :time -> Qex.new()
-            other -> other
-          end)
           |> increase_buffers_size(buffer, timestamp_queue.metric_unit)
           |> check_timestamps_consistency!(buffer, pad_ref)
 
@@ -301,6 +297,11 @@ defmodule Membrane.TimestampQueue do
   defp increase_buffers_size(pad_queue, %Buffer{} = buffer, :time) do
     new_last_timestamp = buffer_time(buffer, pad_queue)
 
+    pad_queue =
+      with %{timestamps_qex: nil} <- pad_queue do
+        %{pad_queue | timestamps_qex: Qex.new()}
+      end
+
     case Qex.last(pad_queue.timestamps_qex) do
       {:value, old_last_timestamp} ->
         time_interval = new_last_timestamp - old_last_timestamp
@@ -385,25 +386,7 @@ defmodule Membrane.TimestampQueue do
   end
 
   @doc """
-  Pushes a buffer and pops items from the queue while they are available.
-
-  Buffers pushed to the queue must have a non-`nil` `dts` or `pts`.
-
-  A buffer `b` from pad `p` is available, if all pads different than `p`
-    - either have a buffer in the queue, that is older than `b`
-    - or haven't ever had any buffer on the queue
-    - or have end of stream pushed on the queue.
-
-  An item other than a buffer is considered available if all newer buffers on the same pad are
-  available.
-
-  The returned value is a suggested actions list, a list of popped items and the updated queue.
-
-  If the amount of buffers associated with any pad in the queue
-   - falls below the `pause_demand_boundary`, the suggested actions list contains
-     `t:Membrane.Action.resume_auto_demand()` actions
-   - rises above the `pause_demand_boundary`, the suggested actions list contains
-     `t:Membrane.Action.pause_auto_demand()` action.
+  The equivalent of calling `push_buffer/2` and then `pop_available_items/1`.
   """
   @spec push_buffer_and_pop_available_items(t(), Pad.ref(), Buffer.t()) ::
           {[Action.pause_auto_demand() | Action.resume_auto_demand()], [popped_value()], t()}
@@ -414,25 +397,13 @@ defmodule Membrane.TimestampQueue do
   @type chunk :: [popped_value()]
 
   @doc """
-  Pops chunked items from the queue while there are enough available items, to create a chunk.
+  Works like `pop_available_items/1`, but the returned items are arranged in chunks of duration `chunk_duration`.
 
-  If there are some available items in the queue, but there are not enough of them to create
-  a chunk, it won't be created.
+  `chunk_duration` must be passed as an option to `new/1`. The duration of each chunk may not be exactly the
+  `chunk_duration`, but the average duration will converge to it. With that exception, only full chunks are
+  returned.
 
-  A buffer `b` from pad `p` is available, if all pads different than `p`
-    - either have a buffer in the queue, that is older than `b`
-    - or haven't ever had any buffer on the queue
-    - or have end of stream pushed on the queue.
-
-  An item other than a buffer is considered available if all newer buffers on the same pad are
-  available.
-
-  The returned value is a suggested actions list, a list of chunks of popped items and the updated
-  queue.
-
-  If the amount of buffers associated with any pad in the queue falls below the
-  `pause_demand_boundary`, the suggested actions list contains `t:Membrane.Action.resume_auto_demand()`
-  actions, otherwise it is an empty list.
+  See `pop_available_items/1` for details.
   """
   @spec pop_chunked(t()) :: {[Action.resume_auto_demand()], [chunk()], t()}
   def pop_chunked(%__MODULE__{chunk_duration: nil}) do
@@ -474,30 +445,7 @@ defmodule Membrane.TimestampQueue do
   end
 
   @doc """
-  Pushes a buffer and pops chunked items from the queue, while there are enough available items,
-  to create a chunk.
-
-  Buffers pushed to the queue must have a non-`nil` `dts` or `pts`.
-
-  If there are some available items in the queue, but there are not enough of them to create
-  a chunk, it won't be created.
-
-  A buffer `b` from pad `p` is available, if all pads different than `p`
-    - either have a buffer in the queue, that is older than `b`
-    - or haven't ever had any buffer on the queue
-    - or have end of stream pushed on the queue.
-
-  An item other than a buffer is considered available if all newer buffers on the same pad are
-  available.
-
-  The returned value is a suggested actions list, a list of chunks of popped items and the updated
-  queue.
-
-  If the amount of buffers associated with any pad in the queue
-   - falls below the `pause_demand_boundary`, the suggested actions list contains
-     `t:Membrane.Action.resume_auto_demand()` actions
-   - rises above the `pause_demand_boundary`, the suggested actions list contains
-     `t:Membrane.Action.pause_auto_demand()` action.
+  The equivalent of calling `push_buffer/2` and then `pop_chunked/1`.
   """
   @spec push_buffer_and_pop_chunked(t(), Pad.ref(), Buffer.t()) ::
           {[Action.pause_auto_demand() | Action.resume_auto_demand()], [popped_value()], t()}

--- a/lib/membrane/timestamp_queue.ex
+++ b/lib/membrane/timestamp_queue.ex
@@ -281,7 +281,6 @@ defmodule Membrane.TimestampQueue do
   defp increase_buffers_size(pad_queue, %Buffer{payload: payload}, :bytes),
     do: %{pad_queue | buffers_size: pad_queue.buffers_size + byte_size(payload)}
 
-
   defp decrease_buffers_size(pad_queue, _buffer, :time) do
     {first_timestamp, timestamps_qex} = Qex.pop!(pad_queue.timestamps_qex)
     pad_queue = %{pad_queue | timestamps_qex: timestamps_qex}
@@ -387,7 +386,6 @@ defmodule Membrane.TimestampQueue do
           else: []
 
       items = [{pad_ref, {:buffer, buffer}}]
-
 
       pop_following_items(timestamp_queue, pad_ref, actions, items)
     else

--- a/lib/membrane/timestamp_queue.ex
+++ b/lib/membrane/timestamp_queue.ex
@@ -393,6 +393,16 @@ defmodule Membrane.TimestampQueue do
     Map.update!(timestamp_queue, :pads_heap, &Heap.push(&1, heap_item))
   end
 
+  @doc """
+  Pops all items in the proper order and closes the queue.
+
+  After being closed, queue is unable handle any new buffer/stream format/event/end of stream.
+
+  The returned value is a suggested actions list, a list of popped buffers and the updated queue.
+
+  Suggested actions list contains `t:Action.resume_auto_demand()` for every pad, that had pasued
+  auto demand before the flush.
+  """
   @spec flush_and_close(t()) :: {[Action.resume_auto_demand()], [popped_value()], t()}
   def flush_and_close(%__MODULE__{} = timestamp_queue) do
     %{timestamp_queue | closed?: true, registered_pads: MapSet.new(), awaiting_pads: []}

--- a/lib/membrane/timestamp_queue.ex
+++ b/lib/membrane/timestamp_queue.ex
@@ -55,8 +55,8 @@ defmodule Membrane.TimestampQueue do
   Options passed to #{inspect(__MODULE__)}.new/1.
 
   Following options are allowed:
-    - `:pause_demand_boundary` - positive integer or `:infinity` (default to `:infinity`). Tells, what
-      amount of buffers associated with specific pad must be stored in the queue, to pause auto demand.
+    - `:pause_demand_boundary` - positive integer, `t:Membrane.Time.t()` or `:infinity` (default to `:infinity`). Tells,
+      what amount of buffers associated with specific pad must be stored in the queue, to pause auto demand.
     - `:pause_demand_boundary_unit` - `:buffers`, `:bytes` or `:time` (deafult to `:buffers`). Tells, in which metric
       `:pause_demand_boundary` is specified.
   """
@@ -98,7 +98,7 @@ defmodule Membrane.TimestampQueue do
   Returns a suggested actions list and the updated queue.
 
   If amount of buffers associated with specified pad in the queue just exceded
-  `pause_demand_boundary`, the suggested actions list contains `t:Action.pause_auto_demand()`
+  `pause_demand_boundary`, the suggested actions list contains `t:Membrane.Action.pause_auto_demand()`
   action, otherwise it is equal an empty list.
 
   Buffers pushed to the queue must have a non-`nil` `dts` or `pts`.
@@ -330,7 +330,7 @@ defmodule Membrane.TimestampQueue do
   The returned value is a suggested actions list, a list of popped buffers and the updated queue.
 
   If the amount of buffers associated with any pad in the queue falls below the
-  `pause_demand_boundary`, the suggested actions list contains `t:Action.resume_auto_demand()`
+  `pause_demand_boundary`, the suggested actions list contains `t:Membrane.Action.resume_auto_demand()`
   actions, otherwise it is an empty list.
   """
   @spec pop_batch(t()) :: {[Action.resume_auto_demand()], [popped_value()], t()}
@@ -434,8 +434,8 @@ defmodule Membrane.TimestampQueue do
 
   The returned value is a suggested actions list, a list of popped buffers and the updated queue.
 
-  Suggested actions list contains `t:Action.resume_auto_demand()` for every pad, that had pasued
-  auto demand before the flush.
+  Suggested actions list contains `t:Membrane.Action.resume_auto_demand()` for every pad, that had
+  pasued auto demand before the flush.
   """
   @spec flush_and_close(t()) :: {[Action.resume_auto_demand()], [popped_value()], t()}
   def flush_and_close(%__MODULE__{} = timestamp_queue) do

--- a/lib/membrane/timestamp_queue/chunker.ex
+++ b/lib/membrane/timestamp_queue/chunker.ex
@@ -1,5 +1,0 @@
-defmodule Membrane.TimestampQueue.Chunker do
-  @moduledoc false
-
-  @type t :: nil
-end

--- a/lib/membrane/timestamp_queue/chunker.ex
+++ b/lib/membrane/timestamp_queue/chunker.ex
@@ -1,0 +1,5 @@
+defmodule Membrane.TimestampQueue.Chunker do
+  @moduledoc false
+
+  @type t :: nil
+end

--- a/test/membrane_timestamp_queue/unit_test.exs
+++ b/test/membrane_timestamp_queue/unit_test.exs
@@ -617,7 +617,7 @@ defmodule Membrane.TimestampQueue.UnitTest do
     end)
   end
 
-  test "push_buffer_and_pop_* functions don't return pause and return demand actions for the same pad" do
+  test "push_buffer_and_pop_* functions don't return pause and resume demand actions for the same pad" do
     queue =
       TimestampQueue.new(
         pause_demand_boundary_unit: :buffers,

--- a/test/membrane_timestamp_queue/unit_test.exs
+++ b/test/membrane_timestamp_queue/unit_test.exs
@@ -3,7 +3,6 @@ defmodule Membrane.TimestampQueue.UnitTest do
 
   require Membrane.Pad, as: Pad
 
-  alias Membrane.StreamFormat
   alias Membrane.Buffer
   alias Membrane.TimestampQueue
 

--- a/test/membrane_timestamp_queue/unit_test.exs
+++ b/test/membrane_timestamp_queue/unit_test.exs
@@ -540,14 +540,15 @@ defmodule Membrane.TimestampQueue.UnitTest do
       end)
 
     dts = Membrane.Time.second() + Membrane.Time.milliseconds(99)
-    buffer =  %Buffer{      dts: dts,      payload: ""    }
+    buffer = %Buffer{dts: dts, payload: ""}
 
-    {[pause_auto_demand: :a], queue} =  TimestampQueue.push_buffer(queue, :a, buffer)
+    {[pause_auto_demand: :a], queue} = TimestampQueue.push_buffer(queue, :a, buffer)
     {[], queue} = TimestampQueue.push_buffer(queue, :b, buffer)
 
     [
-      {&TimestampQueue.pop_available_items/1, &TimestampQueue.push_buffer_and_pop_available_items/3},
-      {&TimestampQueue.pop_chunked/1, &TimestampQueue.push_buffer_and_pop_chunked/3},
+      {&TimestampQueue.pop_available_items/1,
+       &TimestampQueue.push_buffer_and_pop_available_items/3},
+      {&TimestampQueue.pop_chunked/1, &TimestampQueue.push_buffer_and_pop_chunked/3}
     ]
     |> Enum.each(fn {pop_fun, push_and_pop_fun} ->
       buffer = %Buffer{dts: Membrane.Time.second() + Membrane.Time.milliseconds(99), payload: ""}
@@ -577,20 +578,20 @@ defmodule Membrane.TimestampQueue.UnitTest do
         queue
       end)
 
-      [
-        {&TimestampQueue.pop_available_items/1, &TimestampQueue.push_buffer_and_pop_available_items/3},
-        {&TimestampQueue.pop_chunked/1, &TimestampQueue.push_buffer_and_pop_chunked/3},
-      ]
-      |> Enum.each(fn {pop_fun, push_and_pop_fun} ->
-        buffer = %Buffer{dts: Membrane.Time.milliseconds(100), payload: ""}
+    [
+      {&TimestampQueue.pop_available_items/1,
+       &TimestampQueue.push_buffer_and_pop_available_items/3},
+      {&TimestampQueue.pop_chunked/1, &TimestampQueue.push_buffer_and_pop_chunked/3}
+    ]
+    |> Enum.each(fn {pop_fun, push_and_pop_fun} ->
+      buffer = %Buffer{dts: Membrane.Time.milliseconds(100), payload: ""}
 
-        assert {[], items, _queue} = push_and_pop_fun.(queue, :input, buffer)
+      assert {[], items, _queue} = push_and_pop_fun.(queue, :input, buffer)
 
+      {_actions, queue} = TimestampQueue.push_buffer(queue, :input, buffer)
+      {_actions, expected_items, _queue} = pop_fun.(queue)
 
-        {_actions, queue} = TimestampQueue.push_buffer(queue, :input, buffer)
-        {_actions, expected_items, _queue} = pop_fun.(queue)
-
-        assert items == expected_items
-      end)
+      assert items == expected_items
+    end)
   end
 end

--- a/test/membrane_timestamp_queue/unit_test.exs
+++ b/test/membrane_timestamp_queue/unit_test.exs
@@ -477,4 +477,8 @@ defmodule Membrane.TimestampQueue.UnitTest do
       end
     end
   end
+
+  # test "pop_chunked/1 returns properly chunked buffers" do
+  #   queue = TimestampQueue.new(chunk_size)
+  # end
 end

--- a/test/membrane_timestamp_queue/unit_test.exs
+++ b/test/membrane_timestamp_queue/unit_test.exs
@@ -236,7 +236,6 @@ defmodule Membrane.TimestampQueue.UnitTest do
                  TimestampQueue.pop_batch(queue)
 
         queue
-
       end)
     end
   end)


### PR DESCRIPTION
Features implemented in this PR:
 - flushing queue
 - time metric
 - popping chunks
 - push_buffer_and_pop_* functions

Relates to https://github.com/membraneframework/membrane_core/issues/734